### PR TITLE
Allow larger file uploads

### DIFF
--- a/config/nginx/docker_nginx.conf
+++ b/config/nginx/docker_nginx.conf
@@ -10,6 +10,9 @@ http {
     default_type  application/octet-stream;
     client_body_temp_path /tmp/nginx/;
 
+    # Set max request size (up to 4 files x 10Mb size limit)
+    client_max_body_size 40m;
+
     server {
         listen       80;
         server_name  _;


### PR DESCRIPTION
 ## Summary
DM's nginx allows up to 40mb worth of uploads (to accomodate 4x 10mb
files). We should echo this in the dmrunner's nginx so that functional
tests can run correctly against local services.