### PR TITLE
Remove dependency on pyscopg2

### DIFF
--- a/dmrunner/process.py
+++ b/dmrunner/process.py
@@ -5,7 +5,6 @@ import ansicolor
 from contextlib import contextmanager
 import getpass
 import os
-import psycopg2
 import re
 import requests
 import pexpect
@@ -94,10 +93,10 @@ class DMServices(DMExecutable):
 
                 # Connect to Postgres with default parameters - assume a successful connection means postgres is up.
                 try:
-                    psycopg2.connect(dbname='digitalmarketplace', user=getpass.getuser(), host='localhost').close()
+                    subprocess.run(['pg_isready', '-d', 'digitalmarketplace', '-U', getpass.getuser(), '-h', 'localhost'], check=True)
                     healthcheck_result['postgres'] = True
 
-                except psycopg2.OperationalError:
+                except subprocess.CalledProcessError:
                     healthcheck_result['postgres'] = False
 
                 if all(healthcheck_result.values()):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ docker==2.7.0
 pexpect==4.3.1
 prettytable==0.7.2
 psutil==5.2.2
-psycopg2==2.7.3.2
 PyYAML==3.12
 readline==6.2.4.1
 requests==2.18.4


### PR DESCRIPTION
The python package `pyscopg2` is a large requirement that also brings in heavy dependencies (`postgresql-server-dev-*`). However, in dmrunner it is only used to check whether the postgresql server is running.

This commit changes the psql healthcheck to use the `pg_admin` tool that is included with `postgresql-client`. While this is still a fairly large dependency, it is lesser than requiring an entire psql server that
should not even be running.