### PR TITLE
Catch all docker errors

### DIFF
--- a/dmrunner/setup.py
+++ b/dmrunner/setup.py
@@ -143,6 +143,11 @@ def _setup_check_docker_available(logger):
         )
         return EXITCODE_DOCKER_NOT_AVAILABLE
 
+    except Exception as e:
+        logger(red('* Unknown error connecting to Docker. Please make sure it has finished starting up and is running '
+                   'properly: {}'.format(e)))
+        return EXITCODE_DOCKER_NOT_AVAILABLE
+
     try:
         v = docker_client.version()["Version"]
         assert LooseVersion(v) >= LooseVersion(MINIMUM_DOCKER_VERSION)


### PR DESCRIPTION
 ## Summary
Ben had an issue with the docker version check step which just died
without any clear message, possibly because he hadn't given Docker
rights to run with elevated permissions. Unknown which error this is,
and it doesn't really matter - just catch all exceptions and prompt the
user to investigate.