### PR TITLE
Enable g-cloud 9 indexing

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -146,6 +146,14 @@ index:
         create-with-mapping: services-g-cloud-10
 
     - positional:
+        - services
+        - dev
+      keyword:
+        frameworks: g-cloud-9
+        index: g-cloud-9
+        create-with-mapping: services
+
+    - positional:
         - briefs
         - dev
       keyword:


### PR DESCRIPTION
A lot of projects on digitalmarketplace are still g-cloud 9, so to allow 
development with existing projects this commit adds g-cloud 9 to the 
list of indices.