### PR TITLE
Add hooks for black formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ what frameworks need to be indexed for search, etc.
 ## Troubleshooting
 * Troubleshooting tips to go here...
 
+## Code formatting
+This repository uses the opinionated Python code formatter `black` to keep the code consistently styled. Git hooks are
+provided for this repository to seamlessly check and re-style your code as needed. Run `./install_hooks.sh` to install
+the necessary hooks. Alternatively, configure your IDE of choice to run the formatter on save (note: PyCharm currently
+doesn't seem to support this).
+
 ## Todo
 * Refactoring...
 * Add Nix detection to setup and, by default, run apps using Nix to avoid local requirements on node/npm/bower/etc.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ provided for this repository to seamlessly check and re-style your code as neede
 the necessary hooks. Alternatively, configure your IDE of choice to run the formatter on save (note: PyCharm currently
 doesn't seem to support this).
 
+**Note**: If you have your own global git hooks, this may not work. Global and local hooks cannot run at the same time.
+
 ## Todo
 * Refactoring...
 * Add Nix detection to setup and, by default, run apps using Nix to avoid local requirements on node/npm/bower/etc.

--- a/dmrunner/setup.py
+++ b/dmrunner/setup.py
@@ -144,8 +144,12 @@ def _setup_check_docker_available(logger):
         return EXITCODE_DOCKER_NOT_AVAILABLE
 
     except Exception as e:
-        logger(red('* Unknown error connecting to Docker. Please make sure it has finished starting up and is running '
-                   'properly: {}'.format(e)))
+        logger(
+            red(
+                "* Unknown error connecting to Docker. Please make sure it has finished starting up and is running "
+                "properly: {}".format(e)
+            )
+        )
         return EXITCODE_DOCKER_NOT_AVAILABLE
 
     try:

--- a/hooks/install_hooks.sh
+++ b/hooks/install_hooks.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Symbolic links to git hooks need to be installed relative to the hooks directory to be resolved.
+(cd .git/hooks; ln -sf ../../hooks/pre-commit pre-commit)
+(cd .git/hooks; ln -sf ../../hooks/post-commit post-commit)
+echo "DMRunner hooks installed."

--- a/hooks/post-commit
+++ b/hooks/post-commit
@@ -1,0 +1,1 @@
+git update-index -g

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+black_path=$(command -v black)
+if [ ! -x "${black_path}" ]; then
+  echo "ERROR: 'black' formatter is not found in path. Please ensure it's installed."
+  exit 1
+fi
+
+changed_python_files=$(git diff --cached --name-only --diff-filter=ACM | egrep '^.+\.py$')
+if ! [ -z "${changed_python_files}" ]; then
+  black $changed_python_files
+  git add $changed_python_files
+fi


### PR DESCRIPTION
 ## Summary
This patch updates the readme to include notes on the code formatter used for the project, and provides git pre/post-commit hooks to seamlessly apply it (if your IDE cannot be easily configured to use it).

 ## Issue
https://github.com/alphagov/digitalmarketplace-runner/issues/37