### PR TITLE
Change name of local nginx docker image

### DIFF
--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     container_name: dm-nginx
     networks:
       - dmrunner
-    image: "digitalmarketplace/local-nginx:latest"
+    image: "digitalmarketplace/dmrunner-nginx"
     build:
       context: ./
       dockerfile: dockerfile.nginx


### PR DESCRIPTION
The docker image used for nginx in the docker compose file was using a
name that was already taken on Docker hub. This can cause conflicts if
you try to pull that other image. Since we are building from our own
Dockerfile, our image should have its own name.