### PR TITLE
Removes G-Cloud 9 from setup.yml

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -146,14 +146,6 @@ index:
         create-with-mapping: services-g-cloud-10
 
     - positional:
-        - services
-        - dev
-      keyword:
-        frameworks: g-cloud-9
-        index: g-cloud-9
-        create-with-mapping: services
-
-    - positional:
         - briefs
         - dev
       keyword:


### PR DESCRIPTION
# What
This PR is to remove the requirement to index G-Cloud 9 as that data isn't included in the dump any more

# Why
At the moment developers have to manually remove it from the file in order to get the runner to work. This should remove that small but annoying gotcha.