### PR TITLE
Update localhost DNS name

### DIFF
--- a/config/nginx/docker_nginx.conf
+++ b/config/nginx/docker_nginx.conf
@@ -23,43 +23,43 @@ http {
         location / {
             proxy_set_header Authorization "Basic ZGV2LXVzZXI6cGFzc3dvcmQxMjM0NQ==";
             proxy_set_header Host localhost;
-            proxy_pass http://docker.for.mac.localhost:5002;
+            proxy_pass http://host.docker.internal:5002;
         }
 
         location /buyers/direct-award {
             proxy_set_header Authorization "Basic ZGV2LXVzZXI6cGFzc3dvcmQxMjM0NQ==";
             proxy_set_header Host localhost;
-            proxy_pass http://docker.for.mac.localhost:5002;
+            proxy_pass http://host.docker.internal:5002;
         }
 
         location /suppliers {
             proxy_set_header Authorization "Basic ZGV2LXVzZXI6cGFzc3dvcmQxMjM0NQ==";
             proxy_set_header Host localhost;
-            proxy_pass http://docker.for.mac.localhost:5003;
+            proxy_pass http://host.docker.internal:5003;
         }
 
         location /admin {
             proxy_set_header Authorization "Basic ZGV2LXVzZXI6cGFzc3dvcmQxMjM0NQ==";
             proxy_set_header Host localhost;
-            proxy_pass http://docker.for.mac.localhost:5004;
+            proxy_pass http://host.docker.internal:5004;
         }
 
         location /buyers {
             proxy_set_header Authorization "Basic ZGV2LXVzZXI6cGFzc3dvcmQxMjM0NQ==";
             proxy_set_header Host localhost;
-            proxy_pass http://docker.for.mac.localhost:5005;
+            proxy_pass http://host.docker.internal:5005;
         }
 
         location /suppliers/opportunities {
             proxy_set_header Authorization "Basic ZGV2LXVzZXI6cGFzc3dvcmQxMjM0NQ==";
             proxy_set_header Host localhost;
-            proxy_pass http://docker.for.mac.localhost:5006;
+            proxy_pass http://host.docker.internal:5006;
         }
 
         location /user {
             proxy_set_header Authorization "Basic ZGV2LXVzZXI6cGFzc3dvcmQxMjM0NQ==";
             proxy_set_header Host localhost;
-            proxy_pass http://docker.for.mac.localhost:5007;
+            proxy_pass http://host.docker.internal:5007;
         }
     }
 }


### PR DESCRIPTION
docker.for.mac.localhost has been deprecated since 17.12.0

See https://docs.docker.com/docker-for-mac/release-notes/#docker-community-edition-17120-ce-mac46-2018-01-09 for details.

---

 This has been tested on my Macbook Pro with:
  * Docker CE stable version 18.06.1-ce-mac73 (26764)
  * macOS High Sierra version 10.13.6.