### PR TITLE
Add pyflakes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ python:
 install:
   - make install
 script:
-  - make test-black
+  - make test
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -49,3 +49,6 @@ test-black: install
 .PHONY: test-pyflakes
 test-pyflakes: install
 	${VIRTUALENV_ROOT}/bin/pyflakes config/ dmrunner/ main.py setup.py
+
+.PHONY: test
+test: test-black test-pyflakes

--- a/Makefile
+++ b/Makefile
@@ -45,3 +45,7 @@ black: install
 .PHONY: test-black
 test-black: install
 	${VIRTUALENV_ROOT}/bin/black --check config/ dmrunner/ main.py setup.py
+
+.PHONY: test-pyflakes
+test-pyflakes: install
+	${VIRTUALENV_ROOT}/bin/pyflakes config/ dmrunner/ main.py setup.py

--- a/dmrunner/process.py
+++ b/dmrunner/process.py
@@ -84,7 +84,7 @@ class DMServices(DMExecutable):
                     cluster_endpoint = requests.get("http://localhost:9200/_cluster/health")
                     healthcheck_result["elasticsearch"] = cluster_endpoint.status_code == 200
 
-                except (requests.exceptions.ConnectionError, AttributeError) as e:
+                except (requests.exceptions.ConnectionError, AttributeError):
                     healthcheck_result["elasticsearch"] = False
 
                 # Connect to Postgres with default parameters - assume a successful connection means postgres is up.
@@ -103,7 +103,7 @@ class DMServices(DMExecutable):
 
                 time.sleep(1)
 
-        except KeyboardInterrupt as e:
+        except KeyboardInterrupt:
             print(sys.exc_info())
             sys.exit(EXITCODE_NOT_ANTICIPATED_EXECUTION)
 

--- a/dmrunner/runner.py
+++ b/dmrunner/runner.py
@@ -289,7 +289,7 @@ fe / frontend - Run `make frontend-build` against specified apps*
                 except requests.exceptions.ConnectionError:
                     time.sleep(0.5)
 
-                except json.decoder.JSONDecodeError as e:
+                except json.decoder.JSONDecodeError:
                     status = "unknown"
                     error_msg = "Invalid data retrieved from /_status endpoint"
                     break

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -6,8 +6,15 @@ if [ ! -x "${black_path}" ]; then
   exit 1
 fi
 
+pyflakes_path=$(command -v pyflakes)
+if [ ! -x "${pyflakes_path}" ]; then
+  echo "ERROR: 'pyflakes' tool is not found in path. Please ensure it's installed."
+  exit 1
+fi
+
 changed_python_files=$(git diff --cached --name-only --diff-filter=ACM | egrep '^.+\.py$')
 if ! [ -z "${changed_python_files}" ]; then
+  pyflakes $changed_python_files || (echo "ERROR: 'pyflakes' found issues, aborting commit" && exit 1)
   black $changed_python_files
   git add $changed_python_files
 fi

--- a/main.py
+++ b/main.py
@@ -1,11 +1,6 @@
 #!/usr/bin/env python3
 
 import argparse
-import os
-import re
-import subprocess
-import sys
-import yaml
 from dmrunner.runner import DMRunner, RUNNER_COMMANDS
 
 """

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ pexpect==4.3.1
 prettytable==0.7.2
 psutil==5.2.2
 psycopg2==2.7.3.2
+pyflakes==2.0.0
 PyYAML==3.12
 readline==6.2.4.1
 requests==2.18.4


### PR DESCRIPTION
Whilst formatting is enforced by the style-checker `black`, an important part of the work of `flake8` is missing from this repo, namely, static analysis.

This PR adds the tool `pyflakes` into the existing system for quality management. `pyflakes` checks for common Python code errors, independent of style checking; this means that `black` and `pyflakes` are complementary rather than in conflict.

This PR also includes a one-off commit to clean up existing code errors picked up by `pyflakes`; in future however these checks should be performed before each commit (using the git hooks) rather than littering history with clean-up commits.