### PR TITLE
Modularise Docker Compose file

### DIFF
--- a/config/docker-compose.Darwin.yml
+++ b/config/docker-compose.Darwin.yml
@@ -1,0 +1,17 @@
+version: '3.5'
+
+networks:
+  dmrunner:
+    name: dm-net
+    driver: bridge
+
+services:
+  elasticsearch:
+    networks:
+      - dmrunner
+  postgres:
+    networks:
+      - dmrunner
+  nginx:
+    networks:
+      - dmrunner

--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -1,15 +1,8 @@
 version: '3.5'
 
-networks:
-  dmrunner:
-    name: dm-net
-    driver: bridge
-
 services:
   postgres:
     container_name: dm-postgres
-    networks:
-      - dmrunner
     image: "postgres@sha256:f4603c7b8aaf418393edb8cd5e2d1abd91d686ab571302dc83f887ea4a56286b"
     ports:
       - "5432:5432"
@@ -20,16 +13,12 @@ services:
 
   elasticsearch:
     container_name: dm-elasticsearch
-    networks:
-      - dmrunner
     image: "elasticsearch:5.4"
     ports:
       - "9200:9200"
 
   nginx:
     container_name: dm-nginx
-    networks:
-      - dmrunner
     image: "digitalmarketplace/dmrunner-nginx"
     build:
       context: ./dmrunner-nginx

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,8 +5,8 @@
 # moving under each 'repositories' key.
 base-git-url: git@github.com:alphagov
 
-# The path to the Docker compose file used for running services. This shouldn't need to change.
-docker-compose-filepath: config/docker-compose.yml
+# The path to the Docker compose files used for running services. This shouldn't need to change.
+docker-compose-path: config
 
 # The host to query when running healthchecks on apps
 server: localhost

--- a/dmrunner/process.py
+++ b/dmrunner/process.py
@@ -9,6 +9,7 @@ import re
 import requests
 import pathlib
 import pexpect
+import platform
 import signal
 import socket
 import subprocess
@@ -54,8 +55,14 @@ class DMServices(DMExecutable):
         self.run()
 
     @staticmethod
-    def _get_docker_compose_filepaths(docker_compose_folder: Path) -> List[str]:
-        return [pathlib.Path(docker_compose_folder) / "docker-compose.yml"]
+    def _get_docker_compose_filepaths(docker_compose_folder: Path) -> List[Path]:
+        docker_compose_folder = pathlib.Path(docker_compose_folder)
+        docker_compose_machine_filepath = docker_compose_folder / f"docker-compose.{platform.system()}.yml"
+
+        if not docker_compose_machine_filepath.exists():
+            raise RuntimeError(f"operating system {platform.system()} is not yet supported as host for dmrunner")
+
+        return [docker_compose_folder / "docker-compose.yml", docker_compose_machine_filepath]
 
     @staticmethod
     def _get_docker_compose_command(docker_compose_filepaths: Sequence[Path], docker_arg: str) -> List[str]:

--- a/dmrunner/runner.py
+++ b/dmrunner/runner.py
@@ -8,6 +8,7 @@ import itertools
 import json
 import multiprocessing
 import os
+import pathlib
 import prettytable
 import psutil
 import re
@@ -354,8 +355,8 @@ fe / frontend - Run `make frontend-build` against specified apps*
         return tuple(found_apps)
 
     def _start_services(self):
-        docker_compose_filepath = os.path.join(os.path.realpath("."), self.settings["docker-compose-filepath"])
-        self._dmservices = DMServices(logger=self.logger, docker_compose_filepath=docker_compose_filepath)
+        docker_compose_folder = pathlib.Path(pathlib.Path.cwd(), self.settings["docker-compose-path"])
+        self._dmservices = DMServices(logger=self.logger, docker_compose_folder=docker_compose_folder)
         self._dmservices.blocking_healthcheck(self._shutdown)
 
     def _stylize(self, text, **styles):

--- a/dmrunner/setup.py
+++ b/dmrunner/setup.py
@@ -514,7 +514,7 @@ def setup_and_check_requirements(logger: Callable, config: dict, config_path: st
                 )
 
                 with (
-                    background_services(logger, docker_compose_filepath=settings["docker-compose-filepath"], clean=True)
+                    background_services(logger, docker_compose_folder=settings["docker-compose-path"], clean=True)
                     if use_docker_services and not exitcode
                     else blank_context()
                 ):
@@ -538,7 +538,7 @@ def setup_and_check_requirements(logger: Callable, config: dict, config_path: st
             exitcode = exitcode or _setup_check_postgres_data_if_required(logger, settings, use_docker_services)
 
             with (
-                background_services(logger, docker_compose_filepath=settings["docker-compose-filepath"])
+                background_services(logger, docker_compose_folder=settings["docker-compose-path"])
                 if use_docker_services and not exitcode
                 else blank_context()
             ):


### PR DESCRIPTION
Splits the Compose file into a generic part and a operating system specific part.

This is something I've been sitting on for a while, was waiting to get Linux support nailed down but actually it stands alone as a PR.

I run this on my macOS dev machine so it's pretty well teseted, but let me know when you test it out yourself as I'm not so sure about how easy the upgrade path is...

It might also be weird to review because it contains a lot on Python type checking; this was because I found it really hard to design it without it. If people want I can remove it now.