### PR TITLE
Update elasticsearch: 5.4 -> 5.6

### DIFF
--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -13,7 +13,7 @@ services:
 
   elasticsearch:
     container_name: dm-elasticsearch
-    image: "elasticsearch:5.4"
+    image: "elasticsearch:5.6"
     ports:
       - "9200:9200"
 


### PR DESCRIPTION
We are currently running Elasticsearch 5.6.13 in production, so we
should update our dev Elasticsearch version as well.