### PR TITLE
Add a Docker Compose project name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ SHELL := /bin/bash
 VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/venv || echo $$VIRTUAL_ENV)
 .DEFAULT_GOAL := run
 
+export COMPOSE_PROJECT_NAME := dmrunner
+
 .PHONY: virtualenv
 virtualenv:
 	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && python3 -m venv venv || true

--- a/config/docker-compose.Darwin.yml
+++ b/config/docker-compose.Darwin.yml
@@ -2,7 +2,6 @@ version: '3.5'
 
 networks:
   dmrunner:
-    name: dm-net
     driver: bridge
 
 services:

--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -2,7 +2,6 @@ version: '3.5'
 
 services:
   postgres:
-    container_name: dm-postgres
     image: "postgres@sha256:f4603c7b8aaf418393edb8cd5e2d1abd91d686ab571302dc83f887ea4a56286b"
     ports:
       - "5432:5432"
@@ -12,13 +11,11 @@ services:
       POSTGRES_USER: $USER
 
   elasticsearch:
-    container_name: dm-elasticsearch
     image: "elasticsearch:5.6"
     ports:
       - "9200:9200"
 
   nginx:
-    container_name: dm-nginx
     image: "digitalmarketplace/dmrunner-nginx"
     build:
       context: ./dmrunner-nginx


### PR DESCRIPTION
Tweaks the compose file so that you can use a Docker Compose project name; this is useful if you want to run multiple instances of dmrunner for some reason, for instance testing different versions of Elasticsearch.

The default project name is set in the Makefile as `dmrunner`, to change it you can change the Makefile or specify on the commandline as `make ( setup | run ) COMPOSE_PROJECT_NAME=<project_name>`.