### PR TITLE
Add env file that works with `make brew`

### DIFF
--- a/Brewfile.env
+++ b/Brewfile.env
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+eval "$(brew shellenv)"
+
+export PATH="${HOMEBREW_PREFIX}/opt/postgresql@9.6/bin:$PATH"
+
+export NVM_DIR="$HOME/.nvm"
+[ -s "${HOMEBREW_PREFIX}/opt/nvm/nvm.sh" ] && . "${HOMEBREW_PREFIX}/opt/nvm/nvm.sh"  # This loads nvm
+[ -s "${HOMEBREW_PREFIX}/opt/nvm/etc/bash_completion" ] && . "${HOMEBREW_PREFIX}/opt/nvm/etc/bash_completion"  # This loads nvm bash_completion
+[ -f .nvmrc ] && nvm use # This enables nvm
+
+if command -v pyenv >/dev/null 2>&1; then
+	eval "$(pyenv init -)"
+fi

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,51 @@ SHELL := /bin/bash
 VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/venv || echo $$VIRTUAL_ENV)
 .DEFAULT_GOAL := run
 
+PWD_PRETTY := $(subst $(HOME),$$HOME,$(shell pwd))
+
 export COMPOSE_PROJECT_NAME := dmrunner
 
 .PHONY: brew
 brew:
 	brew bundle
 	pyenv install --skip-existing && pyenv version
-	. /usr/local/opt/nvm/nvm.sh && nvm install && npm install -g yarn
+	. Brewfile.env ; nvm install && npm install -g yarn
+	@tput bold
+	@echo '😸 Prerequisites have been installed! 😸'
+	@echo '😺 The following steps are recommended for a seamless experience 😺'
+	@echo -ne '\x31\xEF\xB8\x8F\xE2\x83\xA3  ' # 1
+	@echo -n 'Add the following lines to your shell profile (usually ~/.bash_profile):'
+	@echo -e ' \x31\xEF\xB8\x8F\xE2\x83\xA3'
+	@tput sgr0
+	@echo
+	@echo '[ -s "$(PWD_PRETTY)/Brewfile.env" ] && \'
+	@echo '	. $(PWD_PRETTY)/Brewfile.env'
+	@echo
+	@tput bold
+	@echo -ne '\x32\xEF\xB8\x8F\xE2\x83\xA3  ' # 2
+	@echo -n 'Source the file now so you can continue with the next step:'
+	@echo -e ' \x32\xEF\xB8\x8F\xE2\x83\xA3'
+	@tput sgr0
+	@echo
+	@echo '$ source Brewfile.env'
+	@echo
+	@tput bold
+	@echo -ne '\x33\xEF\xB8\x8F\xE2\x83\xA3  ' # 3
+	@echo -n 'Increase the memory limit of Docker for Mac to 4 GiB'
+	@echo -e ' \x33\xEF\xB8\x8F\xE2\x83\xA3'
+	@tput sgr0
+	@echo
+	@tput bold
+	@echo -ne '\x34\xEF\xB8\x8F\xE2\x83\xA3  ' # 4
+	@echo -n 'You can now try continuing the setup!'
+	@echo -e ' \x34\xEF\xB8\x8F\xE2\x83\xA3'
+	@tput sgr0
+	@echo
+	@echo '$ make setup'
+	@echo
+	@tput bold
+	@echo '😹 Good luck! 😹'
+	@tput sgr0
 
 .PHONY: virtualenv
 virtualenv:

--- a/README.md
+++ b/README.md
@@ -9,18 +9,33 @@ checked out apps.
 
 ## Requirements
 You must have the following tools available in order to successfully use the DM Runner:
-* Python 3, including headers if appropriate (consider using [pyenv]), installed with `pip` and `virtualenv` packages.
-* Node v8.12.0 (consider using [Node Version Manager]), NPM 6+, and Yarn 1.13.0+ installed and available in your path.
-  * The command `nvm install && nvm use` will install and select the correct version of node for you
-* [Docker CE/Docker Desktop for Mac][Docker] 18.03+ installed (if you want backing services managed for you).
-  * By default, the Docker daemon starts with a max RAM allowance of only 2GB. This generally proves insufficient - you should consider raising it to around 4GB.
 
-If you are running macOS and have [Homebrew] installed then you can run `make brew` to install all these prerequisites.
+* Python 3, including headers if appropriate (consider using [pyenv]),
+  installed with `pip` and `virtualenv` packages.
+* Node v8.12.0 (consider using [Node Version Manager]), NPM 6+, and Yarn
+  1.13.0+ installed and available in your path.
+  * If you have NVM the command `nvm install && nvm use` will install and
+    select the correct version of node for you
+* [Docker CE/Docker Desktop for Mac][Docker] 18.03+ installed (if you want
+  backing services managed for you).
+  * By default, the Docker daemon starts with a max RAM allowance of only 2
+    GiB.  This generally proves insufficient - you should consider raising it
+    to around 4 GiB.
+* If you want to automatically decrypt and inject credentials (requires SC
+  clearance and AWS access):
+  * You have a checkout of `digitalmarketplace-credentials` and export the
+    `DM_CREDENTIALS_REPO` environment variable with the path to your local
+    checkout. `DM_CREDENTIALS_REPO/sops-wrapper` must be functional (follow
+    instructions in README).
+  * After running setup, edit the `config.yml` file and change the value of
+    `credentials->sops` to `on`.
 
-* If you want to automatically decrypt and inject credentials (requires SC clearance and AWS access):
-  * You have a checkout of `digitalmarketplace-credentials` and export the `DM_CREDENTIALS_REPO` environment variable with
-    the path to your local checkout. `DM_CREDENTIALS_REPO/sops-wrapper` must be functional (follow instructions in README).
-  * After running setup, edit the `config.yml` file and change the value of `credentials->sops` to `on`.
+If you are running macOS and have [Homebrew] installed then you can run `make
+brew` to install all these prerequisites. It will also suggest you source the
+file `Brewfile.env` into your environment; this will make sure that the correct
+Python and Node versions are in your path, and also ensure that you have the
+correct version of Postgres available to compile the digitalmarketplace-api
+repo against.
 
 [Homebrew]: https://brew.sh
 [Node Version Manager]: https://github.com/nvm-sh/nvm
@@ -35,7 +50,6 @@ If you are running macOS and have [Homebrew] installed then you can run `make br
 4. Run `make` to bring up the Digital Marketplace locally.
 
 ## Using a virtual machine
-
 If you do not use macOS or wish to use a completely isolated environment to use DM Runner you can alternatively use the
 provided `Vagrantfile` to create a virtual machine which contains DM Runner on a Linux box. To use this the only
 requirements are to have Vagrant and VirtualBox installed. You can then access the system using


### PR DESCRIPTION
To try and make it easier for new devs I've tried to simplify setting up the environment for a dmrunner system on macOS.

I've added an file to source, `Brewfile.env`, that can be used to load the required environment variables if `make brew` has been run. `make brew` will then suggest you source that file and add it to your profile.

---

Example output:

[![asciicast](https://asciinema.org/a/vf24YAqvNU4k0MWIlhRjHdO93.svg)](https://asciinema.org/a/vf24YAqvNU4k0MWIlhRjHdO93)