### PR TITLE
Use psycopg2-binary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ mypy==0.710
 pexpect==4.7.0
 prettytable==0.7.2  # pyup: ignore
 psutil==5.6.3
-psycopg2==2.8.3
+psycopg2-binary==2.8.3
 pyflakes==2.1.1
 PyYAML==5.1.1
 readline==6.2.4.1


### PR DESCRIPTION
This should make it easier to install the requirements for dmrunner; building psycopg2 from source (which happens when installing pyscopg2 from PyPI) requires a postgres installation.

Unfortunately this does not completely remove the requirement for postgres from a dmrunner system, as the digitalmarketplace-api app also requires psycopg2 (and we want to build that from source for production).