### PR TITLE
Change the default port for the search api

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -35,7 +35,7 @@ repositories:
     bootstrap: make requirements-dev
     run-order: 1
     healthcheck:
-      port: 5001
+      port: 5009
       endpoint: /_status
     commands:
       run: make run-app


### PR DESCRIPTION
Ticket: https://trello.com/c/cwjzIU8U/1212-stop-search-api-from-using-port-5001

The GDS-managed macOS system includes a VPN tool called Cisco
AnyConnect; the latest version of this has a management daemon that
starts at boot and listens on port 5001, conflicting with the port for
the search api.

As we are unable to change the VPN tool, instead we have to change the
port for the search api :(