### PR TITLE
Remove readline depedency

### DIFF
--- a/dmrunner/runner.py
+++ b/dmrunner/runner.py
@@ -12,7 +12,7 @@ import pathlib
 import prettytable
 import psutil
 import re
-import readline
+import gnureadline as readline  # type: ignore
 import requests
 import shutil
 import signal

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ black==19.10b0
 colored==1.4.2
 configobj==5.0.6
 docker==4.1.0
+gnureadline==8.0.0
 mypy==0.761
 pexpect==4.8.0
 prettytable==0.7.2  # pyup: ignore
@@ -11,6 +12,5 @@ psutil==5.6.7
 psycopg2-binary==2.8.4
 pyflakes==2.1.1
 PyYAML==5.3
-readline==6.2.4.1
 requests==2.22.0
 ruamel.yaml==0.16.7


### PR DESCRIPTION
`readline` from PyPI no longer builds on macOS, as it has been deprecated in favour of `gnureadline`.

This change works on my machine, however other users should test it.