### PR TITLE
Add pyenv environment variables to DMProcess environment

### DIFF
--- a/Brewfile.env
+++ b/Brewfile.env
@@ -11,4 +11,6 @@ export NVM_DIR="$HOME/.nvm"
 
 if command -v pyenv >/dev/null 2>&1; then
 	eval "$(pyenv init -)"
+	echo "Loaded pyenv"
+	echo "Now using Python $(pyenv version)"
 fi

--- a/dmrunner/process.py
+++ b/dmrunner/process.py
@@ -265,9 +265,11 @@ class DMProcess(DMExecutable):
     def _get_clean_env(self):
         clean_env = {"PYTHONUNBUFFERED": "1", "PATH": os.environ["PATH"], "LANG": os.environ["LANG"]}
 
+        pyenv_env = {key: value for key, value in os.environ.items() if key.startswith("PYENV_")}
+
         dm_env = {key: value for key, value in os.environ.items() if key.startswith("DM_")}
 
-        return {**clean_env, **dm_env}
+        return {**clean_env, **dm_env, **pyenv_env}
 
     def _get_command(self, app_command):
         return self._app["commands"][app_command] if app_command in self._app["commands"] else app_command

--- a/dmrunner/runner.py
+++ b/dmrunner/runner.py
@@ -12,7 +12,7 @@ import pathlib
 import prettytable
 import psutil
 import re
-import readline
+import gnureadline as readline  # type: ignore
 import requests
 import shutil
 import signal

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ black==19.10b0
 colored==1.4.2
 configobj==5.0.6
 docker==4.1.0
+gnureadline==8.0.0
 mypy==0.761
 pexpect==4.8.0
 prettytable==0.7.2  # pyup: ignore
@@ -11,6 +12,5 @@ psutil==5.6.7
 psycopg2-binary==2.8.4
 pyflakes==2.1.1
 PyYAML==5.3
-readline==6.2.4.1
 requests==2.22.0
 ruamel.yaml==0.16.7


### PR DESCRIPTION
We want to make sure that the Python version being used to run dmrunner is
also used to run apps.

When managing Python versions with pyenv, this means passing through 
pyenv's environment variables.