### PR TITLE
Add Docker compose config for Redis

### DIFF
--- a/config/docker-compose.Darwin.yml
+++ b/config/docker-compose.Darwin.yml
@@ -17,3 +17,6 @@ services:
   s3:
     networks:
       - dmrunner
+  redis:
+    networks:
+      - dmrunner

--- a/config/docker-compose.Linux.yml
+++ b/config/docker-compose.Linux.yml
@@ -12,3 +12,6 @@ services:
 
   s3:
     network_mode: host
+    
+  redis:
+    network_mode: host

--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -4,6 +4,7 @@ volumes:
   postgres-data:
   elasticsearch-data:
   s3-data:
+  redis-data:
 
 services:
   postgres:
@@ -44,3 +45,10 @@ services:
     volumes:
       - "s3-data:/tmp/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"
+  
+  redis:
+    image: "redis:5"
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data

--- a/config/example-config.yml
+++ b/config/example-config.yml
@@ -64,6 +64,10 @@ styling:
     dm-elasticsearch:
       fg: white
       attr: bold
+    
+    dm-redis:
+      fg: white
+      attr: bold
 
     api:
       fg: blue


### PR DESCRIPTION
https://trello.com/c/XXL04KtG/379-3-run-the-new-user-session-management-on-the-local-development-environment

Add Redis docker image. 

Note, version 5 is used to match PaaS marketplace