### PR TITLE
Change elasticsearch container to run in dev mode

### DIFF
--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       - "9200:9200"
     volumes:
       - elasticsearch-data:/usr/share/elasticsearch/data
+    environment:
+      - "discovery.type=single-node"
 
   nginx:
     image: "nginx:1.14-alpine"


### PR DESCRIPTION
Add envvar to make Elasticsearch run in dev mode [[1]].

This is especially useful on Linux as it means you don't have to increase your `vm.max_map_count` setting.

[1]: https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#docker-cli-run-dev-mode