### PR TITLE
Add localstack to fake s3

### DIFF
--- a/config/docker-compose.Darwin.yml
+++ b/config/docker-compose.Darwin.yml
@@ -14,3 +14,6 @@ services:
   nginx:
     networks:
       - dmrunner
+  s3:
+    networks:
+      - dmrunner

--- a/config/docker-compose.Linux.yml
+++ b/config/docker-compose.Linux.yml
@@ -9,3 +9,6 @@ services:
 
   postgres:
     network_mode: host
+
+  s3:
+    network_mode: host

--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.5'
 volumes:
   postgres-data:
   elasticsearch-data:
+  s3-data:
 
 services:
   postgres:
@@ -28,3 +29,16 @@ services:
       - "80:80"
     volumes:
       - "./dmrunner-nginx/nginx.conf:/etc/nginx/nginx.conf:ro"
+
+  s3:
+    image: "localstack/localstack@sha256:cb08eabae40fa1e33babffa4ff8c454c2276405cfc2fe1e2e300e5625244bdf7"
+    ports:
+      - "4566:4566"
+      - "4571:4571"
+    environment:
+      - SERVICES=s3
+      - DATA_DIR=/tmp/localstack
+      - DEFAULT_REGION=eu-west-1
+    volumes:
+      - "s3-data:/tmp/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,6 +14,11 @@ server: localhost
 data-dump-url: https://s3.console.aws.amazon.com/s3/buckets/digitalmarketplace-cleaned-db-dumps
 sql-data-path: config/sql/data
 
+environment:
+  AWS_ACCESS_KEY_ID: test
+  AWS_SECRET_ACCESS_KEY: test
+  DM_S3_ENDPOINT_PORT: 4566
+
 # Details repositories to be downloaded, bootstrapped, and executed.
 repositories:
   # Core repositories to download and run.

--- a/dmrunner/process.py
+++ b/dmrunner/process.py
@@ -265,11 +265,11 @@ class DMProcess(DMExecutable):
     def _get_clean_env(self):
         clean_env = {"PYTHONUNBUFFERED": "1", "PATH": os.environ["PATH"], "LANG": os.environ["LANG"]}
 
+        aws_env = {key: value for key, value in os.environ.items() if key.startswith("AWS_")}
+        dm_env = {key: value for key, value in os.environ.items() if key.startswith("DM_")}
         pyenv_env = {key: value for key, value in os.environ.items() if key.startswith("PYENV_")}
 
-        dm_env = {key: value for key, value in os.environ.items() if key.startswith("DM_")}
-
-        return {**clean_env, **dm_env, **pyenv_env}
+        return {**clean_env, **aws_env, **dm_env, **pyenv_env}
 
     def _get_command(self, app_command):
         return self._app["commands"][app_command] if app_command in self._app["commands"] else app_command

--- a/dmrunner/runner.py
+++ b/dmrunner/runner.py
@@ -103,6 +103,14 @@ fe / frontend - Run `make frontend-build` against specified apps*
         with open(self._settings_path) as settings_file:
             self.settings: dict = yaml.safe_load(settings_file.read())
 
+        # load environment variables from settings file,
+        # taking care not to override existing envvars
+        if self.settings.get("environment"):
+            for key, value in self.settings["environment"].items():
+                if key not in os.environ:
+                    self.logger(f"setting environment variable {key}")
+                    os.environ[key] = value
+
         self._main_log_name = "setup"
         # Handles initialization of external state required to run this correctly (repos, docker images, config, etc).
         exitcode, self._use_docker_services, self.config = setup_and_check_requirements(

--- a/dmrunner/runner.py
+++ b/dmrunner/runner.py
@@ -190,12 +190,17 @@ fe / frontend - Run `make frontend-build` against specified apps*
                 self.shutdown()
                 sys.exit(1)
 
-            aws_access_key_id = subprocess.check_output(
-                "aws configure get aws_access_key_id".split(), universal_newlines=True
-            )
-            aws_secret_access_key = subprocess.check_output(
-                "aws configure get aws_secret_access_key".split(), universal_newlines=True
-            )
+            if not os.getenv("AWS_ACCESS_KEY_ID"):
+                aws_access_key_id = subprocess.check_output(
+                    "aws configure get aws_access_key_id".split(), universal_newlines=True
+                )
+                os.environ["AWS_ACCESS_KEY_ID"] = aws_access_key_id.strip()
+
+            if not os.getenv("AWS_SECRET_ACCESS_KEY"):
+                aws_secret_access_key = subprocess.check_output(
+                    "aws configure get aws_secret_access_key".split(), universal_newlines=True
+                )
+                os.environ["AWS_SECRET_ACCESS_KEY"] = aws_secret_access_key.strip()
 
             self.print_out(
                 "Decrypting credentials for injection into app processes "
@@ -205,14 +210,13 @@ fe / frontend - Run `make frontend-build` against specified apps*
                 subprocess.check_output(
                     f"{path_to_credentials}/sops-wrapper " f"-d {path_to_credentials}/vars/preview.yaml".split(),
                     universal_newlines=True,
+                    env={"DM_CREDENTIALS_REPO": path_to_credentials, "PATH": os.environ["PATH"]},
                 )
             )
 
             mandrill_key = all_creds["shared_tokens"]["mandrill_key"]
             notify_key = all_creds["notify_api_key"]
 
-            os.environ["AWS_ACCESS_KEY_ID"] = aws_access_key_id.strip()
-            os.environ["AWS_SECRET_ACCESS_KEY"] = aws_secret_access_key.strip()
             os.environ["DM_MANDRILL_API_KEY"] = mandrill_key.strip()
             os.environ["DM_NOTIFY_API_KEY"] = notify_key.strip()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 ansicolor==0.2.6
 ansiwrap==0.8.4
 black==19.10b0
+boto3==1.16.6
 colored==1.4.2
 configobj==5.0.6
 docker==4.2.0


### PR DESCRIPTION
Previously we've needed to use a real s3 bucket (digitalmarketplace-dev-uploads) for local instances of dmrunner to be able to do s3 things.

This PR (in combination with alphagov/digitalmarketplace-utils#580 and alphagov/digitalmarketplace-supplier-frontend#1276) adds a [localstack] instance providing s3 and hooks it up to the Digital Marketplace apps.

To use it you need to make sure you have the latest supplier frontend checked out, and then run `make setup`, which will make sure that your localstack instance has the correct bucket set up. ~dmrunner should still work if you don't have the latest supplier frontend checked out though, just that file uploads and downloads will still go to AWS.~

If you don't want to use this feature, you can either remove the environment variables from config/settings.yml, or set DM_S3_ENDPOINT_URL to the empty string in your environment.

[localstack]: https://github.com/localstack/localstack