### PR TITLE
set redis env var globally

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -18,6 +18,7 @@ environment:
   AWS_ACCESS_KEY_ID: test
   AWS_SECRET_ACCESS_KEY: test
   DM_S3_ENDPOINT_PORT: 4566
+  DM_USE_REDIS_SESSION_TYPE: true
 
 # Details repositories to be downloaded, bootstrapped, and executed.
 repositories:


### PR DESCRIPTION
https://trello.com/c/XXL04KtG/379-3-run-the-new-user-session-management-on-the-local-development-environment
Setting this env var so we can test redis sessions locally.