### PR TITLE
Upgrade Elasticsearch to version 7

### DIFF
--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       POSTGRES_USER: $USER
 
   elasticsearch:
-    image: "elasticsearch:6.8.9"
+    image: "elasticsearch:7.9.3"
     ports:
       - "9200:9200"
     volumes:


### PR DESCRIPTION
Change the Elasticsearch backing service to ES7 to support the search API from [this PR](https://github.com/alphagov/digitalmarketplace-search-api/pull/272) onwards.

This is a **breaking change** and you'll need to follow a few steps to get it to work

1. Stop dm-runner and all the backing services
2. Have the latest version of the search API checked out
3. Delete the old ES6 Docker container and volume
4. Run `make data` to create new indices on ES7