### PR TITLE
remove redis env var 

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -18,7 +18,6 @@ environment:
   AWS_ACCESS_KEY_ID: test
   AWS_SECRET_ACCESS_KEY: test
   DM_S3_ENDPOINT_PORT: 4566
-  DM_USE_REDIS_SESSION_TYPE: true
 
 # Details repositories to be downloaded, bootstrapped, and executed.
 repositories:


### PR DESCRIPTION
https://trello.com/c/VVsPUmkf/595-05-remove-toggle-post-redis-go-live
We no longer need this as feature is enabled by default now.
(note you may need to pull latest version of apps to ensure sessions keep working)