### PR TITLE
bump to postgres 12

### DIFF
--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -8,7 +8,7 @@ volumes:
 
 services:
   postgres:
-    image: "postgres:10.15@sha256:95f79893ef4d769277f7687b03bb24fe77a49ad2ec1c269f89a0cf849d6f4c7b"                                                                   
+    image: "postgres:12"
     ports:
       - "5432:5432"
     volumes:


### PR DESCRIPTION
https://trello.com/c/yUrkl9Tk/707-05-ensure-dmp-is-compatible-with-postgres-12

Upgrade dmrunner to postgres 12. Note: no minor version is specified, as it is not specified by PaaS.