### PR TITLE
Add digitalmarketplace-developer-tools to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ black==20.8b1
 boto3==1.17.17
 colored==1.4.2
 configobj==5.0.6
+digitalmarketplace-developer-tools==0.0.2
 docker==4.4.4
 gnureadline==8.0.0
 invoke==1.5.0


### PR DESCRIPTION
To be able to use invoke with a Digital Marketplace repo the package digitalmarketplace-developer-tools normally needs to be installed.