### PR TITLE
Add support for Linux with rootless Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ nix-rebuild: virtualenv
 
 .PHONY: black
 black: install
-	$(MAIN_PY) dmrunner/ main.py setup.py
+	black config/ dmrunner/ main.py setup.py
 
 .PHONY: test-black
 test-black: install

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ DMRunner also provides an interactive shell to manage processes and their logs.
 
 ## Requirements
 
-DMRunner is compatible with macOS and Ubuntu 16.04.
+DMRunner is compatible with macOS and Ubuntu 20.04.
 
 Running against other OSs may require some care and consideration.
 

--- a/config/docker-compose.Darwin.yml
+++ b/config/docker-compose.Darwin.yml
@@ -12,6 +12,11 @@ services:
     networks:
       - dmrunner
   nginx:
+    image: "nginx:1.14-alpine"
+    ports:
+      - "80:80"
+    volumes:
+      - "./dmrunner-nginx/nginx.conf:/etc/nginx/nginx.conf:ro"
     networks:
       - dmrunner
   s3:

--- a/config/docker-compose.Linux.yml
+++ b/config/docker-compose.Linux.yml
@@ -1,14 +1,1 @@
 version: '3.5'
-
-services:
-  elasticsearch:
-    network_mode: host
-
-  postgres:
-    network_mode: host
-
-  s3:
-    network_mode: host
-    
-  redis:
-    network_mode: host

--- a/config/docker-compose.Linux.yml
+++ b/config/docker-compose.Linux.yml
@@ -4,9 +4,6 @@ services:
   elasticsearch:
     network_mode: host
 
-  nginx:
-    network_mode: host
-
   postgres:
     network_mode: host
 

--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -27,13 +27,6 @@ services:
     environment:
       - "discovery.type=single-node"
 
-  nginx:
-    image: "nginx:1.14-alpine"
-    ports:
-      - "80:80"
-    volumes:
-      - "./dmrunner-nginx/nginx.conf:/etc/nginx/nginx.conf:ro"
-
   s3:
     image: "localstack/localstack@sha256:cb08eabae40fa1e33babffa4ff8c454c2276405cfc2fe1e2e300e5625244bdf7"
     ports:

--- a/dmrunner/process.py
+++ b/dmrunner/process.py
@@ -101,7 +101,11 @@ class DMServices(DMExecutable):
                 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 try:
                     s.connect(("localhost", 80))
-                    healthcheck_result["nginx"] = True
+                    # DM Runner is incapable of managing nginx on some systems (such as rootless docker). To support
+                    # these systems where DM runner may only be managing elasticsearch and postgres, we record a
+                    # healthcheck failure, but not success.
+                    if 'nginx' in healthcheck_result:
+                        del healthcheck_result["nginx"]
 
                 except ConnectionError:
                     healthcheck_result["nginx"] = False

--- a/dmrunner/process.py
+++ b/dmrunner/process.py
@@ -104,7 +104,7 @@ class DMServices(DMExecutable):
                     # DM Runner is incapable of managing nginx on some systems (such as rootless docker). To support
                     # these systems where DM runner may only be managing elasticsearch and postgres, we record a
                     # healthcheck failure, but not success.
-                    if 'nginx' in healthcheck_result:
+                    if "nginx" in healthcheck_result:
                         del healthcheck_result["nginx"]
 
                 except ConnectionError:

--- a/dmrunner/setup.py
+++ b/dmrunner/setup.py
@@ -249,11 +249,11 @@ def _setup_check_background_services(logger):
 
     logger(bold("Checking for existing background services..."))
     healthcheck_passed, healthcheck_results = DMServices.services_healthcheck(threading.Event(), check_once=True)
-    first_result = next(iter(healthcheck_results.values()))  # Used to ensure all results are identical
+    first_result = next(iter(healthcheck_results.values()))  # Used to check if all results are identical
 
-    if not healthcheck_passed and not all(map(lambda x: x is first_result, healthcheck_results.values())):
-        services_up = [x[0].title() for x in list(filter(lambda y: y[1] is True, healthcheck_results.items()))]
-        services_down = [x.title() for x in set(healthcheck_results.keys()) - set([x.lower() for x in services_up])]
+    if not healthcheck_passed and not all(result is first_result for result in healthcheck_results.values()):
+        services_up = [service.title() for service, result in healthcheck_results.items() if result is True]
+        services_down = [service.title() for service, result in healthcheck_results.items() if result is False]
         logger(
             red(
                 "* You have some services running locally (Up: {}. Down: {}).".format(


### PR DESCRIPTION
DM runner has has Linux support for a while. However, whoever originally set it up had a rather different system to mine. Their docker had root access, so worked a bit differently to me. A Linux user with rootless docker needs to set up nginx themselves - this is already documented in the readme.

To get it running on my system, I needed to manage nginx separately and change some networking settings.

This will inconvenience any Linux users who have given their docker root access. I believe I am the only Linux user, however, so this isn't a problem.

Also did a bit of refactoring. I think generators make the health check logic clearer.