### PR TITLE
Add missing healthchecks for background services

### DIFF
--- a/dmrunner/process.py
+++ b/dmrunner/process.py
@@ -115,9 +115,7 @@ class DMServices(DMExecutable):
     def is_postgres_up():
         """Connect to Postgres with default parameters - assume a successful connection means postgres is up."""
         try:
-            psycopg2.connect(
-                dbname="digitalmarketplace", user=os.getenv("USER", "postgres"), host="localhost"
-            ).close()
+            psycopg2.connect(dbname="digitalmarketplace", user=os.getenv("USER", "postgres"), host="localhost").close()
             return True
         except psycopg2.OperationalError:
             return False
@@ -125,7 +123,7 @@ class DMServices(DMExecutable):
     @staticmethod
     def is_redis_up():
         try:
-            redis.Redis(host='localhost', port=6379, db=0).get('test')
+            redis.Redis(host="localhost", port=6379, db=0).get("test")
             return True
         except redis.exceptions.RedisError:
             return False
@@ -145,8 +143,8 @@ class DMServices(DMExecutable):
         """Attempts to validate that required background services (NGINX, Elasticsearch, Postgres) are all
         operational. It takes some shortcuts in doing so, but should be effective in most cases."""
         healthcheck_result = {
-            "nginx": False, 
-            "elasticsearch": False, 
+            "nginx": False,
+            "elasticsearch": False,
             "postgres": False,
             "redis": False,
             "localstack": False,

--- a/dmrunner/process.py
+++ b/dmrunner/process.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 import os
 import psycopg2
 import re
+import redis
 import requests
 import pathlib
 import pexpect
@@ -122,6 +123,14 @@ class DMServices(DMExecutable):
             return False
 
     @staticmethod
+    def is_redis_up():
+        try:
+            redis.Redis(host='localhost', port=6379, db=0).get('test')
+            return True
+        except redis.exceptions.RedisError:
+            return False
+
+    @staticmethod
     def services_healthcheck(shutdown_event, check_once=False):
         """Attempts to validate that required background services (NGINX, Elasticsearch, Postgres) are all
         operational. It takes some shortcuts in doing so, but should be effective in most cases."""
@@ -140,6 +149,7 @@ class DMServices(DMExecutable):
 
                 healthcheck_result["elasticsearch"] = DMServices.is_elasticsearch_up()
                 healthcheck_result["postgres"] = DMServices.is_postgres_up()
+                healthcheck_result["redis"] = DMServices.is_redis_up()
 
                 if all(healthcheck_result.values()):
                     break

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,6 @@ psutil==5.8.0
 psycopg2-binary==2.8.6
 pyflakes==2.3.1
 PyYAML==5.4.1
+redis==3.5.3
 requests==2.25.1
 ruamel.yaml==0.17.0


### PR DESCRIPTION
We want healthchecks for our background services so we can be sure that they're all operational before we start the apps. We've recently added Redis and Localstack. Add healthchecks for the two new apps.

Also, given the number of background services now, break the individual healthchecks out to make the logic clearer.

I've tested that this works for me on Ubuntu. I'd like a reviewer on MacOS to check out this branch and check that they can run `make run` successfully.