### PR TITLE
Add docker-compose to requirements files

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,7 @@ configobj
 dataclasses;python_version<"3.7"  # via black
 digitalmarketplace-developer-tools
 docker
+docker-compose
 gnureadline
 invoke
 mypy

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,10 @@ ansiwrap==0.8.4
     # via -r requirements.in
 appdirs==1.4.4
     # via black
+attrs==20.3.0
+    # via jsonschema
+bcrypt==3.2.0
+    # via paramiko
 black==20.8b1
     # via -r requirements.in
 boto3==1.17.39
@@ -18,8 +22,15 @@ botocore==1.20.51
     # via
     #   boto3
     #   s3transfer
+cached-property==1.5.2
+    # via docker-compose
 certifi==2020.12.5
     # via requests
+cffi==1.14.5
+    # via
+    #   bcrypt
+    #   cryptography
+    #   pynacl
 chardet==4.0.0
     # via requests
 click==7.1.2
@@ -30,20 +41,33 @@ colored==1.4.2
     # via -r requirements.in
 configobj==5.0.6
     # via -r requirements.in
+cryptography==3.4.7
+    # via paramiko
 dataclasses==0.8 ; python_version < "3.7"
     # via
     #   -r requirements.in
     #   black
 digitalmarketplace-developer-tools==0.1.1
     # via -r requirements.in
-docker==4.4.4
+distro==1.5.0
+    # via docker-compose
+docker-compose==1.29.0
     # via -r requirements.in
+docker[ssh]==5.0.0
+    # via
+    #   -r requirements.in
+    #   docker-compose
+dockerpty==0.4.1
+    # via docker-compose
+docopt==0.6.2
+    # via docker-compose
 gnureadline==8.0.0
     # via -r requirements.in
 idna==2.10
     # via requests
 importlib-metadata==3.10.1
     # via
+    #   jsonschema
     #   pep517
     #   prettytable
 invoke==1.5.0
@@ -54,12 +78,16 @@ jmespath==0.10.0
     # via
     #   boto3
     #   botocore
+jsonschema==3.2.0
+    # via docker-compose
 mypy-extensions==0.4.3
     # via
     #   black
     #   mypy
 mypy==0.812
     # via -r requirements.in
+paramiko==2.7.2
+    # via docker
 pathspec==0.8.1
     # via black
 pep517==0.10.0
@@ -76,12 +104,22 @@ psycopg2-binary==2.8.6
     # via -r requirements.in
 ptyprocess==0.7.0
     # via pexpect
+pycparser==2.20
+    # via cffi
 pyflakes==2.3.1
     # via -r requirements.in
+pynacl==1.4.0
+    # via paramiko
+pyrsistent==0.17.3
+    # via jsonschema
 python-dateutil==2.8.1
     # via botocore
+python-dotenv==0.17.0
+    # via docker-compose
 pyyaml==5.4.1
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   docker-compose
 redis==3.5.3
     # via -r requirements.in
 regex==2021.4.4
@@ -90,6 +128,7 @@ requests==2.25.1
     # via
     #   -r requirements.in
     #   docker
+    #   docker-compose
 ruamel.yaml.clib==0.2.2
     # via ruamel.yaml
 ruamel.yaml==0.17.0
@@ -98,10 +137,15 @@ s3transfer==0.3.7
     # via boto3
 six==1.15.0
     # via
+    #   bcrypt
     #   configobj
-    #   docker
+    #   dockerpty
+    #   jsonschema
+    #   pynacl
     #   python-dateutil
     #   websocket-client
+texttable==1.6.3
+    # via docker-compose
 textwrap3==0.9.2
     # via ansiwrap
 toml==0.10.2
@@ -124,7 +168,9 @@ urllib3==1.26.4
 wcwidth==0.2.5
     # via prettytable
 websocket-client==0.58.0
-    # via docker
+    # via
+    #   docker
+    #   docker-compose
 zipp==3.4.1
     # via
     #   importlib-metadata
@@ -132,3 +178,4 @@ zipp==3.4.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip
+# setuptools


### PR DESCRIPTION
Running backing servies with dmrunner requires docker-compose. Adding it to the requirements file ensures that it will be installed.